### PR TITLE
demo gdc 2025

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
 
     steps:
     - name: checkout

--- a/Sentaur.Leaderboard.AntiCheat/Sentaur.Leaderboard.AntiCheat.csproj
+++ b/Sentaur.Leaderboard.AntiCheat/Sentaur.Leaderboard.AntiCheat.csproj
@@ -2,14 +2,16 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
-        <PackageReference Include="Sentry.Google.Cloud.Functions" Version="4.2.1" />
+        <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
+        <!-- Can bump once this ships: -->
+        <!-- https://github.com/getsentry/sentry-dotnet/pull/4039/-->
+        <PackageReference Include="Sentry.Google.Cloud.Functions" Version="4.13.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sentaur.Leaderboard.Api/Sentaur.Leaderboard.Api.csproj
+++ b/Sentaur.Leaderboard.Api/Sentaur.Leaderboard.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Sentry.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="Sentry.Profiling" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
@@ -35,9 +36,13 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <SentryOrg>demo</SentryOrg>
-    <SentryProject>sentaur-survivor-leaderboard-api</SentryProject>
-<!--    <SentryUploadSymbols>true</SentryUploadSymbols>-->
+    <SentryProject>sentaur-survivors-leaderboard</SentryProject>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <SentryCreateRelease>true</SentryCreateRelease>
+    <SentrySetCommits>true</SentrySetCommits>
     <EmbedAllSources>true</EmbedAllSources>
+    <!-- Using EmbedAllSources already so no need to use SentryUploadSources -->
+    <!-- <SentryUploadSources>true</SentryUploadSources> -->
   </PropertyGroup>
 
 </Project>

--- a/Sentaur.Leaderboard.Api/Sentaur.Leaderboard.Api.csproj
+++ b/Sentaur.Leaderboard.Api/Sentaur.Leaderboard.Api.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
-    <PackageReference Include="Sentry.AspNetCore" Version="4.2.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Sentry.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sentaur.Leaderboard.Api/appsettings.json
+++ b/Sentaur.Leaderboard.Api/appsettings.json
@@ -7,8 +7,11 @@
   },
   "AllowedHosts": "*",
   "Sentry":  {
-    "Dsn": "https://5d0a57235954f67390e247d52b9190ca@o87286.ingest.us.sentry.io/4506888440053760",
-    "EnableTracing": true
+    "Dsn": "https://de39606043c0b0a7482ebd54f060871f@o87286.ingest.us.sentry.io/4508985365037056",
+    "TracesSampleRate": 1.0,
+    "ProfilesSampleRate": 0.0,
+    "Release": "1.0.25",
+    "Debug": true
   },
   "Jwt": {
     "Issuer": "https://sentaur-survivor.com/"

--- a/Sentaur.Leaderboard.Web/Program.cs
+++ b/Sentaur.Leaderboard.Web/Program.cs
@@ -7,20 +7,17 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-// Blazor built-in integration is in a Draft: https://github.com/getsentry/sentry-dotnet/pull/2569/
-builder.Logging.AddSentry(o =>
+builder.UseSentry(o =>
 {
     o.Dsn = "https://8f3ccd6a8a8e5ba417de8df962236a7d@o87286.ingest.us.sentry.io/4506888120107008";
-    o.EnableTracing = true;
-
-    // System.PlatformNotSupportedException: System.Diagnostics.Process is not supported on this platform.
-    o.DetectStartupTime = StartupTimeDetectionMode.Fast;
-    // Warning: No response compression supported by HttpClientHandler.
-    o.RequestBodyCompressionLevel = CompressionLevel.NoCompression;
+    o.TracesSampleRate = 1.0;
 });
 
-builder.Services.AddScoped(sp => new HttpClient(
-    // Sentry tracing integration:
-    new SentryHttpMessageHandler()) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Logging.AddSentry(o => o.InitializeSdk = false);
+
+
+// builder.Services.AddScoped(sp => new HttpClient(
+//     // Sentry tracing integration:
+//     new SentryHttpMessageHandler()) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 await builder.Build().RunAsync();

--- a/Sentaur.Leaderboard.Web/Program.cs
+++ b/Sentaur.Leaderboard.Web/Program.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Sentaur.Leaderboard.Web;
@@ -9,15 +8,14 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.UseSentry(o =>
 {
-    o.Dsn = "https://8f3ccd6a8a8e5ba417de8df962236a7d@o87286.ingest.us.sentry.io/4506888120107008";
+    o.Dsn = "https://de39606043c0b0a7482ebd54f060871f@o87286.ingest.us.sentry.io/4508985365037056";
     o.TracesSampleRate = 1.0;
+    o.Release = "1.0.25";
+    o.Debug = true;
 });
 
-builder.Logging.AddSentry(o => o.InitializeSdk = false);
-
-
-// builder.Services.AddScoped(sp => new HttpClient(
-//     // Sentry tracing integration:
-//     new SentryHttpMessageHandler()) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(sp => new HttpClient(
+    // Sentry tracing integration:
+    new SentryHttpMessageHandler()) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 await builder.Build().RunAsync();

--- a/Sentaur.Leaderboard.Web/Sentaur.Leaderboard.Web.csproj
+++ b/Sentaur.Leaderboard.Web/Sentaur.Leaderboard.Web.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.2"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.2" PrivateAssets="all"/>
-        <PackageReference Include="Sentry.Extensions.Logging" Version="4.2.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
+        <PackageReference Include="Sentry.AspNetCore.Blazor.WebAssembly" Version="5.4.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -23,9 +23,13 @@
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
       <SentryOrg>demo</SentryOrg>
-      <SentryProject>sentaur-survivor-leaderboard-app</SentryProject>
-<!--      <SentryUploadSymbols>true</SentryUploadSymbols>-->
+      <SentryProject>sentaur-survivors-leaderboard</SentryProject>
+      <SentryUploadSymbols>true</SentryUploadSymbols>
+      <SentryCreateRelease>true</SentryCreateRelease>
+      <SentrySetCommits>true</SentrySetCommits>
       <EmbedAllSources>true</EmbedAllSources>
+      <!-- Using EmbedAllSources already so no need to use SentryUploadSources -->
+      <!-- <SentryUploadSources>true</SentryUploadSources> -->
     </PropertyGroup>
 
 </Project>

--- a/Sentaur.Leaderboard.Web/wwwroot/index.html
+++ b/Sentaur.Leaderboard.Web/wwwroot/index.html
@@ -32,24 +32,30 @@
       <a href="" class="reload">Reload</a>
       <a class="dismiss">🗙</a>
     </div>
-    <script
-            src="https://js.sentry-cdn.com/8f3ccd6a8a8e5ba417de8df962236a7d.min.js"
-            crossorigin="anonymous"
-    ></script>
     <script>
-        Sentry.onLoad(function() {
-            Sentry.init({
-                integrations: [
-                    Sentry.replayIntegration({
-                        // No PII in this site
-                        maskAllText: false,
-                        blockAllMedia: false,
-                    }),
-                ],
-                replaysSessionSampleRate: 1.0,
-            });
+      window.sentryOnLoad = function () {
+        Sentry.init({
+          release: "1.0.25",
+          environment: "production",
+          debug: true,
+          replaysSessionSampleRate: 1.0,
+          profilesSampleRate: 1.0,
+          tracesSampleRate: 1.0,
+          tracePropagationTargets: ["localhost", /^https:\/\/sentaur-survivor\.com\//],
+          integrations: [
+            // Add browser profiling integration to the list of integrations
+            Sentry.browserTracingIntegration(),
+            Sentry.browserProfilingIntegration(),
+            Sentry.replayIntegration({
+              // No PII in this site
+              maskAllText: false,
+              blockAllMedia: false,
+            }),
+          ],
         });
+      };
     </script>
+    <script src="https://js.sentry-cdn.com/de39606043c0b0a7482ebd54f060871f.min.js" crossorigin="anonymous"></script>
     <script src="_framework/blazor.webassembly.js"></script>
   </body>
 </html>

--- a/Sentaur.Leaderboard/Sentaur.Leaderboard.csproj
+++ b/Sentaur.Leaderboard/Sentaur.Leaderboard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
Profiling for the backend is off. Since the product doesn't pick a relevant thread by default and it's not great to have to pick one.
And since it's all sync, not super insightful as-is. We'd need to improve the demo to make it sense.

Having Blazor + JS on the frontend while both are disconnected (trace not connected) is not ideal. So we might be better off removing the Blazor tracing altogether.

TODO:
1. Set up stack trace linking
2. Make sure source context work
3. Automate version bumping (right now hard coded to 1.0.25, since GDC 25)
  * While  .NET has automatic versionining, JS wouldn't have any. Ideally we automate a version that aligns across the layers
  * Adjust release since sentry-cli sends the automatic one as it's unaware of whats given via `Init`